### PR TITLE
v1.3.1

### DIFF
--- a/app/assets/javascripts/cambium/admin/users.js
+++ b/app/assets/javascripts/cambium/admin/users.js
@@ -1,2 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.

--- a/app/assets/javascripts/cambium/admin/views/editor.js.coffee
+++ b/app/assets/javascripts/cambium/admin/views/editor.js.coffee
@@ -4,6 +4,7 @@ class App.Views.Editor extends Backbone.View
     for textarea in $('textarea.editor')
       $(textarea).trumbowyg
         fullscreenable: false
+        svgPath: TRUMBOWYG_SVG
         btns: ['viewHTML',
           '|', 'formatting',
           '|', 'strong', 'em',

--- a/app/assets/stylesheets/cambium/admin/partials/activity.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/activity.scss
@@ -2,7 +2,7 @@ aside#activity {
   background: $color-light-dark;
   border-left: 1px solid $color-light-darker;
   padding: 25px 10px;
-  box-sizing(border-box);
+  box-sizing: border-box;;
   article {
     margin: 0 0 30px 0;
     &:last-child {

--- a/app/assets/stylesheets/cambium/admin/partials/activity.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/activity.scss
@@ -2,7 +2,7 @@ aside#activity {
   background: $color-light-dark;
   border-left: 1px solid $color-light-darker;
   padding: 25px 10px;
-  @include box-sizing(border-box);
+  box-sizing(border-box);
   article {
     margin: 0 0 30px 0;
     &:last-child {

--- a/app/assets/stylesheets/cambium/admin/partials/components.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/components.scss
@@ -5,7 +5,7 @@ div.status{
   width: 100%;
   z-index: 99999;
   text-align: center;
-  @include box-sizing(border-box);
+  box-sizing(border-box);
   p.notice, p.alert {
     margin: 0;
     padding: 25px 0;

--- a/app/assets/stylesheets/cambium/admin/partials/components.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/components.scss
@@ -5,7 +5,7 @@ div.status{
   width: 100%;
   z-index: 99999;
   text-align: center;
-  box-sizing(border-box);
+  box-sizing: border-box;;
   p.notice, p.alert {
     margin: 0;
     padding: 25px 0;

--- a/app/assets/stylesheets/cambium/admin/partials/forms.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/forms.scss
@@ -102,7 +102,7 @@ section.form {
         vertical-align: bottom;
         font-size: 16px;
         border: none;
-        box-sizing(border-box);
+        box-sizing: border-box;;
         &[readonly=readonly] {
           background-color: $color-light-dark;
           border-bottom-color: $color-light-dark;
@@ -225,7 +225,7 @@ section.form {
       display: block;
       width: 100%;
       margin: 15px 0 0 0;
-      box-sizing(border-box);
+      box-sizing: border-box;;
       @include transition(all 0.35s linear);
       font-size: 16px;
       font-weight: 600;

--- a/app/assets/stylesheets/cambium/admin/partials/forms.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/forms.scss
@@ -37,14 +37,13 @@ section.form {
         & + .image-actions, & + img + .image-actions, .image-actions {
           display: block;
           clear: both;
-          width: 100%;
-          margin: 5px 0 20px;
+          width: 75%;
+          margin: 5px 0 20px 25%;
           font-size: 14px;
           line-height: 14px;
-          text-align: right;
           a {
             display: inline-block;
-            margin-left: 10px;
+            margin-right: 10px;
           }
         }
         & + div.input {

--- a/app/assets/stylesheets/cambium/admin/partials/forms.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/forms.scss
@@ -167,15 +167,23 @@ section.form {
       .trumbowyg-box {
         display: inline-block;
         width: 75%;
+        min-height: 375px;
         margin: 5px 0;
         &.trumbowyg-fullscreen {
+          width: 100%;
+        }
+        .trumbowyg-button-pane button {
+          margin: 0 0 1px;
+        }
+        textarea {
+          border: none;
           width: 100%;
         }
       }
       .trumbowyg-modal {
         // position: fixed;
         .trumbowyg-modal-box {
-          height: 295px;
+          height: 315px;
           form {
             input {
               height: auto;
@@ -198,6 +206,7 @@ section.form {
               width: auto;
               .trumbowyg-input-infos {
                 float: left;
+                margin-top: -24px;
                 span {
                   font-size: 14px;
                   border: none;

--- a/app/assets/stylesheets/cambium/admin/partials/forms.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/forms.scss
@@ -102,7 +102,7 @@ section.form {
         vertical-align: bottom;
         font-size: 16px;
         border: none;
-        @include box-sizing(border-box);
+        box-sizing(border-box);
         &[readonly=readonly] {
           background-color: $color-light-dark;
           border-bottom-color: $color-light-dark;
@@ -225,7 +225,7 @@ section.form {
       display: block;
       width: 100%;
       margin: 15px 0 0 0;
-      @include box-sizing(border-box);
+      box-sizing(border-box);
       @include transition(all 0.35s linear);
       font-size: 16px;
       font-weight: 600;

--- a/app/assets/stylesheets/cambium/admin/partials/header.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/header.scss
@@ -50,7 +50,7 @@ header {
     float: right;
     height: 60px;
     padding: 0;
-    @include box-sizing(border-box);
+    box-sizing(border-box);
     // border-left: 1px solid $color-5-dark;
     @include transition-all;
     &:hover {

--- a/app/assets/stylesheets/cambium/admin/partials/header.scss
+++ b/app/assets/stylesheets/cambium/admin/partials/header.scss
@@ -50,7 +50,7 @@ header {
     float: right;
     height: 60px;
     padding: 0;
-    box-sizing(border-box);
+    box-sizing: border-box;;
     // border-left: 1px solid $color-5-dark;
     @include transition-all;
     &:hover {

--- a/app/controllers/cambium/admin_controller.rb
+++ b/app/controllers/cambium/admin_controller.rb
@@ -1,6 +1,8 @@
 class Cambium::AdminController < Cambium::BaseController
 
   before_filter :authenticate_admin!
+
+  before_filter :set_paper_trail_whodunnit
   before_filter :set_activities
 
   layout "admin"

--- a/app/controllers/cambium/pages_controller.rb
+++ b/app/controllers/cambium/pages_controller.rb
@@ -1,17 +1,41 @@
 class Cambium::PagesController < ApplicationController
 
+  before_filter :set_page, :only => [:show]
+  before_filter :set_home_page, :only => [:home]
+
+  if Cambium.configuration.cache_pages
+    caches_action :show, :cache_path => :page_cache_path.to_proc
+    caches_action :home, :cache_path => :page_cache_path.to_proc
+  end
+
   def show
-    @page = Cambium::Page.find_by_page_path(request.path)
     render :inline => @page.template.content, :layout => 'application'
   end
 
   def home
-    @page = Cambium::Page.home
     if @page.nil?
       render 'home_missing'
     else
       render :inline => @page.template.content, :layout => 'application'
     end
   end
+
+  protected
+
+    def set_page
+      @page = Cambium::Page.find_by_page_path(request.path)
+    end
+
+    def set_home_page
+      @page = Cambium::Page.home
+    end
+
+    def q_to_s
+      request.query_parameters.to_a.collect { |q| "_#{q[0]}_#{q[1]}"  }.join('')
+    end
+
+    def page_cache_path
+      "_p#{@page.id}#{q_to_s}"
+    end
 
 end

--- a/app/helpers/cambium/cambium_helper.rb
+++ b/app/helpers/cambium/cambium_helper.rb
@@ -162,7 +162,7 @@ module Cambium
 
     def cambium_field(f, obj, field)
       attr = field.first.to_s
-      options = field.last
+      options = field.is_a?(OpenStruct) ? field : field.last
       options = options.to_ostruct unless options.class == OpenStruct
       readonly = options.readonly || false
       label = options.label || attr.titleize

--- a/app/helpers/cambium/cambium_helper.rb
+++ b/app/helpers/cambium/cambium_helper.rb
@@ -213,7 +213,7 @@ module Cambium
         end
       elsif options.type == 'wysiwyg'
         f.input(attr.to_sym, :as => :text, :label => label,
-                :input_html => { :class => 'editor' })
+                :input_html => { :class => 'editor' }, :required => required)
       elsif options.type == 'media'
         content_tag(:div, :class => 'input media-picker file') do
           o2  = content_tag(:label, label)

--- a/app/helpers/cambium/cambium_helper.rb
+++ b/app/helpers/cambium/cambium_helper.rb
@@ -258,7 +258,7 @@ module Cambium
         o
       else
         f.input(attr.to_sym, :as => options.type, :label => label,
-                :readonly => readonly)
+                :readonly => readonly, :required => required)
       end
     end
 

--- a/app/helpers/cambium/cambium_helper.rb
+++ b/app/helpers/cambium/cambium_helper.rb
@@ -235,24 +235,46 @@ module Cambium
         o = f.input(attr.to_sym, :as => options.type, :label => label,
                 :readonly => readonly, :required => required)
         unless obj.send(attr).blank?
-          if ['jpg','jpeg','gif','png'].include?(obj.send(attr).ext.downcase)
-            o += image_tag obj.send(attr)
-                              .thumb("200x200##{obj.send("#{attr}_gravity")}")
-                              .url
-            o += content_tag(:div, :class => 'image-actions') do
-              o2  = ''.html_safe
-              o2 += link_to('Crop Image', '#', :class => 'crop',
-                            :target => :blank, :data => {
-                            :url => obj.send(attr).url,
-                            :width => obj.send(attr).width,
-                            :height => obj.send(attr).height }) if options.crop
-              o2 += link_to(obj.send(attr).name, obj.send(attr).url,
-                       :class => 'file', :target => :blank)
-              o2 += f.input :"#{attr}_gravity", :as => :hidden
-            end
-          else
-            o += link_to(obj.send(attr).name, obj.send(attr).url,
+          # Dragonfly ...
+          if obj.send(attr).respond_to?(:ext)
+            if %w(jpg jpeg gif png).include?(obj.send(attr).ext.downcase)
+              o += image_tag obj.send(attr)
+                                .thumb("200x200##{obj.send("#{attr}_gravity")}")
+                                .url
+              o += content_tag(:div, :class => 'image-actions') do
+                o2  = ''.html_safe
+                o2 += link_to('Crop Image', '#', :class => 'crop',
+                              :target => :blank, :data => {
+                              :url => obj.send(attr).url,
+                              :width => obj.send(attr).width,
+                              :height => obj.send(attr).height }) if options.crop
+                o2 += link_to(obj.send(attr).name, obj.send(attr).url,
                          :class => 'file', :target => :blank)
+                o2 += f.input :"#{attr}_gravity", :as => :hidden
+              end
+            else
+              o += link_to(obj.send(attr).name, obj.send(attr).url,
+                           :class => 'file', :target => :blank)
+            end
+          # CarrierWave (assumed, for now)
+          else
+            if %w(jpg jpeg gif png).include?(obj.send(attr).file.extension.downcase)
+              o += image_tag obj.send(attr).thumb.url
+              o += content_tag(:div, :class => 'image-actions') do
+                o2  = ''.html_safe
+                # o2 += link_to('Crop Image', '#', :class => 'crop',
+                #               :target => :blank, :data => {
+                #               :url => obj.send(attr).url,
+                #               :width => obj.send(attr).width,
+                #               :height => obj.send(attr).height }) if options.crop
+                o2 += link_to(obj.send(attr).file.filename, obj.send(attr).url,
+                         :class => 'file', :target => :blank)
+                # o2 += f.input :"#{attr}_gravity", :as => :hidden
+              end
+            else
+              o += link_to(obj.send(attr).name, obj.send(attr).url,
+                           :class => 'file', :target => :blank)
+            end
           end
         end
         o

--- a/app/models/cambium/document.rb
+++ b/app/models/cambium/document.rb
@@ -1,6 +1,8 @@
 module Cambium
   class Document < ActiveRecord::Base
 
+    extend Dragonfly::Model
+
     # ------------------------------------------ Plugins
 
     include PgSearch

--- a/app/models/cambium/page.rb
+++ b/app/models/cambium/page.rb
@@ -53,7 +53,9 @@ module Cambium
 
     def method_missing(method, *arguments, &block)
       if respond_to?(method.to_s)
-        if template.fields[method.to_s]['type'] == 'media'
+        if template.fields[method.to_s.gsub(/\?$/, '')]['type'] == 'boolean'
+          template_data[method.to_s.gsub(/\?$/, '')].to_i == 1
+        elsif template.fields[method.to_s]['type'] == 'media'
           Cambium::Document.find_by_id(template_data[method.to_s].to_i)
         else
           template_data[method.to_s]
@@ -67,6 +69,9 @@ module Cambium
       return true if super
       return false if template.blank?
       return true if template.fields.keys.include?(method.to_s)
+      template.fields.each do |name, attrs|
+        return true if attrs["type"] == 'boolean' && method.to_s == "#{name}?"
+      end
       false
     end
 

--- a/app/models/cambium/page.rb
+++ b/app/models/cambium/page.rb
@@ -22,6 +22,7 @@ module Cambium
 
     after_save :cache_page_path
     after_save :reload_routes!
+    after_save :expire_caches
 
     # ------------------------------------------ Class Methods
 
@@ -83,6 +84,10 @@ module Cambium
 
       def cache_page_path
         update_columns(:page_path => "/#{path.collect(&:slug).join('/')}")
+      end
+
+      def expire_caches
+        Rails.cache.delete_matched(/\_p#{id}(.*)/)
       end
 
   end

--- a/app/views/cambium/admin/_header.html.erb
+++ b/app/views/cambium/admin/_header.html.erb
@@ -14,20 +14,14 @@
     <% end %>
     <div class="dropdown-menu">
       <ul>
-        <%= content_tag(
-          :li,
-          link_to(
-            'Edit Profile',
-            cambium.edit_admin_user_path(current_user)
-          )
-        ) %>
-        <%= content_tag(
-          :li,
-          link_to(
-            'Sign Out',
-            main_app.destroy_user_session_path,
-          )
-        ) %>
+        <li>
+          <%= link_to 'Edit Profile',
+                      cambium.edit_admin_user_path(current_user) %>
+        </li>
+        <li>
+          <%= link_to 'Sign Out', main_app.destroy_user_session_path,
+                      :method => :delete %>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/cambium/admin/edit.html.erb
+++ b/app/views/cambium/admin/edit.html.erb
@@ -1,7 +1,6 @@
 <%= cambium_page_title(admin_form.title) %>
 
-<%= content_tag(
-  :div,
-  cambium_form(@object, admin_form.fields),
-  :id => 'page-content'
-) %>
+<div id="page-content"
+     data-library="<%= cambium.admin_documents_path(:no_layout => true) %>">
+  <%= cambium_form(@object, admin_form.fields) %>
+</div>

--- a/app/views/cambium/admin/new.html.erb
+++ b/app/views/cambium/admin/new.html.erb
@@ -1,7 +1,6 @@
 <%= cambium_page_title(admin_form.title) %>
 
-<%= content_tag(
-  :div,
-  cambium_form(@object, admin_form.fields),
-  :id => 'page-content'
-) %>
+<div id="page-content"
+     data-library="<%= cambium.admin_documents_path(:no_layout => true) %>">
+  <%= cambium_form(@object, admin_form.fields) %>
+</div>

--- a/app/views/cambium/admin/settings/index.html.erb
+++ b/app/views/cambium/admin/settings/index.html.erb
@@ -4,10 +4,8 @@
   <section class="form settings">
     <% @collection.each do |obj| %>
       <%= simple_form_for [:admin, obj] do |f| %>
-        <%= f.input :value,
-                    :as => admin_view.form.edit.fields.send(obj.key).type,
-                    :label => admin_view.form.edit.fields.send(obj.key).label,
-                    :input_html => { :id => obj.key } %>
+        <% field = [:value, admin_view.form.edit.fields.send(obj.key)] %>
+        <%= cambium_field(f, obj, field) %>
         <%= f.submit "Save #{admin_view.form.edit.fields.send(obj.key).label}" %>
       <% end %>
     <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,6 +8,9 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="format-detection" content="telephone=no">
+    <script>
+      TRUMBOWYG_SVG = '<%= image_path('trumbowyg/images/icons.svg') %>';
+    </script>
     <%= stylesheet_link_tag 'cambium/admin/application', :media => 'all' %>
     <%= javascript_include_tag "modernizr" %>
     <%= csrf_meta_tags %>

--- a/cambium.gemspec
+++ b/cambium.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency 'factory_girl_rails'
 
-  spec.add_dependency 'actionpack-action_caching'
   spec.add_dependency 'ancestry'
   spec.add_dependency 'bones-rails', '>= 1.1.3'
   spec.add_dependency 'dragonfly'

--- a/cambium.gemspec
+++ b/cambium.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency 'factory_girl_rails'
 
+  spec.add_dependency 'actionpack-action_caching'
   spec.add_dependency 'ancestry'
   spec.add_dependency 'bones-rails', '>= 1.1.3'
   spec.add_dependency 'dragonfly'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,14 @@ Cambium::Engine.routes.draw do
 
   if ActiveRecord::Base.connection.table_exists?('cambium_pages')
     Cambium::Page.published.each do |page|
+      template = page.template
+      next if template.nil? || page.page_path.blank?
       begin
-        get page.page_path => 'pages#show' unless page.page_path.blank?
+        if template.respond_to?(:controller) && template.respond_to?(:action)
+          get page.page_path => "/#{template.controller}##{template.action}"
+        else
+          get page.page_path => 'pages#show'
+        end
       rescue
       end
     end

--- a/lib/cambium/configuration.rb
+++ b/lib/cambium/configuration.rb
@@ -2,13 +2,15 @@ module Cambium
   class Configuration
 
     attr_accessor :app_title,
+                  :cache_pages,
                   :development_url,
                   :production_url
 
     def initialize
+      @app_title            = 'Cambium'
+      @cache_pages          = false
       @development_url      = 'localhost:3000'
       @production_url       = 'example.com'
-      @app_title            = 'Cambium'
     end
 
   end

--- a/lib/cambium/version.rb
+++ b/lib/cambium/version.rb
@@ -1,3 +1,3 @@
 module Cambium
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/lib/generators/cambium/controller_generator.rb
+++ b/lib/generators/cambium/controller_generator.rb
@@ -32,10 +32,10 @@ module Cambium
     # end
 
     def confirm_model
-      @model = model.constantize
-    rescue
-      puts "Can't find the model: #{model}"
-      exit
+      @model = model.classify.singularize.constantize
+    # rescue
+    #   puts "Can't find the model: #{model}"
+    #   exit
     end
 
     def set_model_attrs

--- a/lib/generators/templates/config/initializers/assets.rb
+++ b/lib/generators/templates/config/initializers/assets.rb
@@ -1,3 +1,3 @@
 Rails.application.config.assets.precompile += %w(
   modernizr.js trumbowyg/images/icons.png trumbowyg/images/icons-2x.png
-)
+  trumbowyg/images/icons.svg)

--- a/lib/generators/templates/config/initializers/cambium.rb
+++ b/lib/generators/templates/config/initializers/cambium.rb
@@ -13,4 +13,11 @@ Cambium.configure do |config|
   #
   config.app_title = 'Cambium'
 
+  # -------------------------------------------------- Caching
+
+  # Cambium's Pages come with caching support. It is disabled by default, but
+  # you can enabled it by uncommenting the following line:
+  #
+  # config.cache_pages = true
+
 end

--- a/lib/generators/templates/config/initializers/cambium.rb
+++ b/lib/generators/templates/config/initializers/cambium.rb
@@ -15,8 +15,10 @@ Cambium.configure do |config|
 
   # -------------------------------------------------- Caching
 
-  # Cambium's Pages come with caching support. It is disabled by default, but
-  # you can enabled it by uncommenting the following line:
+  # Cambium's Pages come with action caching support. It is disabled by default.
+  # Uncomment the setting below to enable action caching.
+  #
+  # NOTE: You must install the 'actionpack-action_caching' gem for this to work.
   #
   # config.cache_pages = true
 


### PR DESCRIPTION
New features:

- Can override a controller/action combo in a page template
- Add action caching option for pages
- Add custom field support to global settings

Fixes:

- User `delete` for sign out
- Don't need to have Dragonfly in app Gemfile
- squash a few WYSIWYG functional/style bugs
- Set PaperTrail whodunnit to `current_user`
- Don't auto-require wysiwyg and generic fields